### PR TITLE
Feature/travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ before_install:
   - tar xzf android-sdk-linux.tgz
   - export ANDROID_HOME="$(pwd)/android-sdk-linux"
   - export PATH="${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools"
-  - yes y | android update sdk --no-ui --force --filter build-tools-20.0.0,android-16,platform-tools,extra-android-support,extra-android-m2repository
+  # Partition downloads into licence groups, otherwise `echo "y"` doesn't work
+  - echo "y" | android update sdk --no-ui --force --filter build-tools-20.0.0,android-16,platform-tools,extra-android-support
+  - echo "y" | android update sdk --no-ui --force --filter extra-android-m2repository
 
   # Come back into main repository
   - cd ${MAIN_REPO}


### PR DESCRIPTION
Bloody Android SDK has no option to accept licenses automatically, and fails silently if any license is not accepted (and doesn't install the required packages). So the Android Support Maven Repository wasn't getting installed because, having a different license, the `echo "y"` didn't reach the second prompt for license acceptance.

Solution: break the sdk install line into one line per license, with an `echo "y"` in front of each.

Thank you Android for being silent about this and wasting me hours looking for the problem...
