### PR TITLE
Annotate injected object's methods for Android >= 17

### DIFF
--- a/daydreaming/src/main/java/com/brainydroid/daydreaming/ui/dashboard/ResultsActivity.java
+++ b/daydreaming/src/main/java/com/brainydroid/daydreaming/ui/dashboard/ResultsActivity.java
@@ -6,6 +6,7 @@ import android.graphics.Bitmap;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.View;
+import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.LinearLayout;
@@ -63,10 +64,12 @@ public class ResultsActivity extends RoboFragmentActivity {
             this.resultsWrap = resultsWrap;
         }
 
+        @JavascriptInterface
         public int getVersionCode() {
             return versionCode;
         }
 
+        @JavascriptInterface
         public String getResultsWrap() {
             return resultsWrap;
         }


### PR DESCRIPTION
Otherwise, they're not available from inside the Javascript.

Fixes #400.
