### PR TITLE
Show information popup on editing activities in evening questionnaire

### DIFF
--- a/daydreaming/src/main/java/com/brainydroid/daydreaming/background/StatusManager.java
+++ b/daydreaming/src/main/java/com/brainydroid/daydreaming/background/StatusManager.java
@@ -85,6 +85,7 @@ public class StatusManager {
     private static String RESULTS_DOWNLOADED = "resultsDownloaded";
     public static String NOTIFICATION_EXPIRY_EXPLAINED = "notificationExpiryExplained";
     public static String GLOSSARY_EXPLAINED = "glossaryExplained";
+    public static String EQ_EDIT_ACTIVITIES_EXPLAINED = "eqEditActivitiesExplained";
 
     public static final String ACTION_PARAMETERS_STATUS_CHANGE = "actionParametersStatusChange";
 
@@ -559,6 +560,7 @@ public class StatusManager {
         clear(ARE_RESULTS_NOTIFIED_DASHBOARD);
         clear(NOTIFICATION_EXPIRY_EXPLAINED);
         clear(GLOSSARY_EXPLAINED);
+        clear(EQ_EDIT_ACTIVITIES_EXPLAINED);
         clearResultsDownloaded();
 
         // Cancel any running location collection and pending notifications.
@@ -595,6 +597,7 @@ public class StatusManager {
         clear(ARE_RESULTS_NOTIFIED_DASHBOARD);
         clear(NOTIFICATION_EXPIRY_EXPLAINED);
         clear(GLOSSARY_EXPLAINED);
+        clear(EQ_EDIT_ACTIVITIES_EXPLAINED);
         clearResultsDownloaded();
 
         // Clear crypto storage to force a new handshake

--- a/daydreaming/src/main/java/com/brainydroid/daydreaming/ui/sequences/PageActivity.java
+++ b/daydreaming/src/main/java/com/brainydroid/daydreaming/ui/sequences/PageActivity.java
@@ -43,7 +43,8 @@ public class PageActivity extends RoboFragmentActivity {
 
     private static String TAG = "PageActivity";
 
-    public static String EXTRA_SEQUENCE_ID = "sequenceId";
+    public static final String EXTRA_SEQUENCE_ID = "sequenceId";
+    private static final String EQ_ACTIVITY_PAGE_NAME = "usualActivities";
 
     private int sequenceId;
     private Sequence sequence;
@@ -62,6 +63,8 @@ public class PageActivity extends RoboFragmentActivity {
 
     @InjectResource(R.string.page_too_late_title) String tooLateTitle;
     @InjectResource(R.string.page_too_late_body) String tooLateBody;
+    @InjectResource(R.string.page_eq_edit_activities_title) String explanationTitle;
+    @InjectResource(R.string.page_eq_edit_activities_text) String explanationText;
 
     @Inject private PageViewAdapter pageViewAdapter;
     @Inject LocationServiceConnection locationServiceConnection;
@@ -116,6 +119,24 @@ public class PageActivity extends RoboFragmentActivity {
         } else {
             Logger.i(TAG, "No data or no location -> not starting listening" +
                     " tasks");
+        }
+
+        if (currentPage.getName().equals(EQ_ACTIVITY_PAGE_NAME) &&
+                !statusManager.is(StatusManager.EQ_EDIT_ACTIVITIES_EXPLAINED)) {
+            Logger.d(TAG, "Edition of evening activities not yet explained, showing popup");
+            statusManager.set(StatusManager.EQ_EDIT_ACTIVITIES_EXPLAINED);
+
+            AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+            alertBuilder.setCancelable(false)
+                    .setTitle(explanationTitle)
+                    .setMessage(explanationText)
+                    .setPositiveButton("Got it", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            dialogInterface.cancel();
+                        }
+                    });
+            alertBuilder.show();
         }
     }
 

--- a/daydreaming/src/main/res/values/strings.xml
+++ b/daydreaming/src/main/res/values/strings.xml
@@ -197,6 +197,8 @@
     <string name="page_edit_mode_cancel">Cancel</string>
     <string name="page_too_late_title">Oops, too late!</string>
     <string name="page_too_late_body">Probes are meant to be answered quickly, so we can\'t let you answer this one. From now on notifications will disappear on their own after a few minutes. If you want to answer a probe you missed, you can do so in the dashboard, it will suggest any missed probes.</string>
+    <string name="page_eq_edit_activities_title">Edit your activities</string>
+    <string name="page_eq_edit_activities_text">This page is about what you did in your day. Scroll down to the bottom of the page to edit what activities show up here!</string>
 
     <!-- Display question Activity -->
     <string name="question_welcome_text">HERE ARE A FEW QUICK QUESTIONS:</string>


### PR DESCRIPTION
@MklBst careful from now on: l'appli détecte s'il faut montrer ou non le popup en se basant sur le nom de la page courante. Si c'est "usualActivities", elle montre le popup (que la première fois).

Donc actuellement dans les paramètres "usualActivities" n'apparaît qu'une fois dans les page names (ici : https://github.com/daydreaming-experiment/parameters/blob/master/grammar-v3.1/production.json#L2286), et **il faut ni renommer cette page ni mettre d'autres pages avec ce nom, sinon, unpredictable behaviour ensues** :).
